### PR TITLE
Created wrap files for range-v3 0.3.6

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,7 @@
+project('range-v3', 'cpp', version: '0.3.6', license: 'Boost, libc++, Stepanov and McJones, "Elements of Programming", SGI STL')
+
+range_inc = include_directories('include')
+
+range_dep = declare_dependency(
+  include_directories : range_inc
+)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
-project('range-v3', 'cpp', version: '0.3.6', license: 'Boost, libc++, Stepanov and McJones "Elements of Programming", SGI STL')
+project('range-v3', 'cpp', version: '0.3.6',
+        license: 'Boost, libc++, Stepanov and McJones "Elements of Programming", SGI STL')
 
 range_inc = include_directories('include')
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('range-v3', 'cpp', version: '0.3.6', license: 'Boost, libc++, Stepanov and McJones, "Elements of Programming", SGI STL')
+project('range-v3', 'cpp', version: '0.3.6', license: 'Boost, libc++, Stepanov and McJones "Elements of Programming", SGI STL')
 
 range_inc = include_directories('include')
 

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+directory = range-v3-0.3.6
+source_url = https://github.com/ericniebler/range-v3/archive/0.3.6.zip
+source_filename = range-v3-0.3.6.zip
+source_hash = 42cafd42fd51555844eb129018188f4cc7d9a60cbcc1fcb98496cd8942e5fadf


### PR DESCRIPTION
Here is a wrap file for the range-v3. Well, the license string is quite long, and I wasn't sure if I need to break it into multiple lines. 